### PR TITLE
change dict values to list

### DIFF
--- a/train.py
+++ b/train.py
@@ -203,7 +203,7 @@ class TrainingHelper(object):
         if self.task == Task.nugget:
             return metrics["nugget"]["rnss"]
         if self.task == Task.quality:
-            return np.mean(metrics["quality"]["rsnod"].values())
+            return np.mean(list(metrics["quality"]["rsnod"].values()))
 
 
 


### PR DESCRIPTION
This error occurred when I run.

```
Traceback (most recent call last):
  File "train.py", line 227, in <module>
    trainer.train()
  File "train.py", line 148, in train
    curr_score = self.metrics_to_single_value(metrics)
  File "train.py", line 206, in metrics_to_single_value
    return np.mean(metrics["quality"]["rsnod"].values())
  File "/home/skato/.pyenv/versions/anaconda3-5.1.0/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 2920, in mean
    out=out, **kwargs)
  File "/home/skato/.pyenv/versions/anaconda3-5.1.0/lib/python3.6/site-packages/numpy/core/_methods.py", line 87, in _mean
    ret = ret / rcount
TypeError: unsupported operand type(s) for /: 'dict_values' and 'int'
```